### PR TITLE
Таблицы УПК: Доработан подход вывода ошибок

### DIFF
--- a/КР.tab/Документация.panel/Спецификации.pulldown/Таблицы УПК.pushbutton/script.py
+++ b/КР.tab/Документация.panel/Спецификации.pulldown/Таблицы УПК.pushbutton/script.py
@@ -58,6 +58,8 @@ CONCRETE_MARK = "обр_ФОП_Марка бетона B"
 BUILDING_INFO = "Наименование здания"
 
 ERROR_MESSAGE = "Выполнение скрипта прервано!"
+form_number_min_for_rebar = 1000
+form_number_min_for_embedded = 2000
 
 class RevitRepository:
     """
@@ -193,7 +195,7 @@ class RevitRepository:
                 elif element_type.IsExistsParam(FORM_NUMBER):
                     number_value = element_type.GetParamValue(FORM_NUMBER)
 
-                if number_value >= 2000:
+                if number_value >= form_number_min_for_embedded:
                     if not element.IsExistsParam(parameter_name) and not element_type.IsExistsParam(parameter_name):
                         self.__add_error("Арматура___Отсутствует параметр у экземпляра или типоразмера___", element, parameter_name)
 
@@ -249,10 +251,10 @@ class RevitRepository:
                 else:
                     form_number = element_type.GetParamValueOrDefault(FORM_NUMBER)
 
-                if form_number < 1000:
-                    self.__add_error("Арматура___В арматуре значение параметра меньше 1000. Обновите семейство!___",
+                if form_number < form_number_min_for_rebar:
+                    self.__add_error('Арматура___В арматуре значение параметра меньше {}. Обновите семейство!___'.format(form_number_min_for_rebar),
                                      element, FORM_NUMBER)
-                elif 1000 <= form_number < 2000:
+                elif form_number_min_for_rebar <= form_number < form_number_min_for_embedded:
                     if element.IsExistsParam(parameter_name):
                         if not element.GetParam(parameter_name).HasValue or element.GetParamValue(parameter_name) == None:
                             self.__add_error("Арматура___Отсутствует значение у параметра (экземпляра или типа)___",
@@ -268,7 +270,7 @@ class RevitRepository:
                 elif element_type.IsExistsParam(FORM_NUMBER):
                     number_value = element_type.GetParamValue(FORM_NUMBER)
 
-                if number_value >= 2000:
+                if number_value >= form_number_min_for_embedded:
                     if element.IsExistsParam(parameter_name):
                         if not element.GetParam(parameter_name).HasValue or element.GetParamValue(parameter_name) == None:
                             self.__add_error("Арматура___Отсутствует значение у параметра (экземпляра или типа)___", element, parameter_name)
@@ -664,7 +666,7 @@ class Construction:
             else:
                 form_number = element_type.GetParamValue(FORM_NUMBER)
 
-            if 1000 <= form_number < 2000:
+            if form_number_min_for_rebar <= form_number < form_number_min_for_embedded:
                 if diameter in self.__diameter_dict.keys():
                     mass_per_metr = self.__diameter_dict[diameter]
                 else:

--- a/КР.tab/Документация.panel/Спецификации.pulldown/Таблицы УПК.pushbutton/script.py
+++ b/КР.tab/Документация.panel/Спецификации.pulldown/Таблицы УПК.pushbutton/script.py
@@ -57,6 +57,7 @@ PYLON_CROSS_SECTION_WIDTH = "ФОП_РАЗМ_Ширина"
 CONCRETE_MARK = "обр_ФОП_Марка бетона B"
 BUILDING_INFO = "Наименование здания"
 
+ERROR_MESSAGE = "Выполнение скрипта прервано!"
 
 class RevitRepository:
     """
@@ -815,7 +816,7 @@ class Construction:
                 value = element_type.GetParam(CONCRETE_MARK).AsValueString()
                 if value is None:
                     print("В элементе с ID \"{}\" не заполнен параметр \"{}\"!".format(element.Id, CONCRETE_MARK))
-                    print("Выполнение скрипта прервано!")
+                    print(ERROR_MESSAGE)
                     script.exit()
                 concrete_class = "В" + value
                 concrete_classes.add(concrete_class)
@@ -1027,7 +1028,7 @@ class CreateQualityTableCommand(ICommand):
             output.print_table(table_data=check,
                                title="Показатели качества",
                                columns=["Категории", "Тип ошибки", "Название параметра", "Id"])
-            print("Выполнение скрипта прервано!")
+            print(ERROR_MESSAGE)
             script.exit()
 
         # Приступаем к проверке арматуры проекта
@@ -1045,7 +1046,7 @@ class CreateQualityTableCommand(ICommand):
             output.print_table(table_data=check,
                                title="Показатели качества",
                                columns=["Категории", "Тип ошибки", "Название параметра", "Id"])
-            print("Выполнение скрипта прервано!")
+            print(ERROR_MESSAGE)
             script.exit()
 
         # Выполняем фильтрацию элементов арматуры по пользовательским исключениям
@@ -1061,7 +1062,7 @@ class CreateQualityTableCommand(ICommand):
             output.print_table(table_data=check,
                                title="Показатели качества",
                                columns=["Категории", "Тип ошибки", "Название параметра", "Id"])
-            print("Выполнение скрипта прервано!")
+            print(ERROR_MESSAGE)
             script.exit()
 
         # Фильтруем родительские семейства арматуры
@@ -1079,7 +1080,7 @@ class CreateQualityTableCommand(ICommand):
             output.print_table(table_data=check,
                                title="Показатели качества",
                                columns=["Категории", "Тип ошибки", "Название параметра", "Id"])
-            print("Выполнение скрипта прервано!")
+            print(ERROR_MESSAGE)
             script.exit()
 
         check = self.__view_model.revit_repository.check_rebar_parameters_values(rebar)
@@ -1088,7 +1089,7 @@ class CreateQualityTableCommand(ICommand):
             output.print_table(table_data=check,
                                title="Показатели качества",
                                columns=["Категории", "Тип ошибки", "Название параметра", "Id"])
-            print("Выполнение скрипта прервано!")
+            print(ERROR_MESSAGE)
             script.exit()
 
         selected_table_type = self.__view_model.selected_table_type
@@ -1389,7 +1390,7 @@ def script_execute(plugin_logger):
         output.print_table(table_data=check,
                            title="Показатели качества",
                            columns=["Категории", "Тип ошибки", "Название параметра", "Id"])
-        print("Выполнение скрипта прервано!")
+        print(ERROR_MESSAGE)
         script.exit()
 
     revit_repository.filter_concrete_by_main_exceptions()

--- a/КР.tab/Документация.panel/Спецификации.pulldown/Таблицы УПК.pushbutton/script.py
+++ b/КР.tab/Документация.panel/Спецификации.pulldown/Таблицы УПК.pushbutton/script.py
@@ -250,8 +250,8 @@ class RevitRepository:
                     form_number = element_type.GetParamValueOrDefault(FORM_NUMBER)
 
                 if form_number < 1000:
-                    self.__add_error('Арматура___В арматуре значение "{}" меньше 1000. Обновите семейство!___'.format(FORM_NUMBER),
-                                     element, parameter_name)
+                    self.__add_error("Арматура___В арматуре значение параметра меньше 1000. Обновите семейство!___",
+                                     element, FORM_NUMBER)
                 elif 1000 <= form_number < 2000:
                     if element.IsExistsParam(parameter_name):
                         if not element.GetParam(parameter_name).HasValue or element.GetParamValue(parameter_name) == None:

--- a/КР.tab/Документация.panel/Спецификации.pulldown/Таблицы УПК.pushbutton/script.py
+++ b/КР.tab/Документация.panel/Спецификации.pulldown/Таблицы УПК.pushbutton/script.py
@@ -249,7 +249,10 @@ class RevitRepository:
                 else:
                     form_number = element_type.GetParamValueOrDefault(FORM_NUMBER)
 
-                if 1000 <= form_number < 2000:
+                if form_number < 1000:
+                    self.__add_error('Арматура___В арматуре значение "{}" меньше 1000. Обновите семейство!___'.format(FORM_NUMBER),
+                                     element, parameter_name)
+                elif 1000 <= form_number < 2000:
                     if element.IsExistsParam(parameter_name):
                         if not element.GetParam(parameter_name).HasValue or element.GetParamValue(parameter_name) == None:
                             self.__add_error("Арматура___Отсутствует значение у параметра (экземпляра или типа)___",

--- a/КР.tab/Документация.panel/Спецификации.pulldown/Таблицы УПК.pushbutton/script.py
+++ b/КР.tab/Документация.panel/Спецификации.pulldown/Таблицы УПК.pushbutton/script.py
@@ -1023,6 +1023,7 @@ class CreateQualityTableCommand(ICommand):
             output.print_table(table_data=check,
                                title="Показатели качества",
                                columns=["Категории", "Тип ошибки", "Название параметра", "Id"])
+            print("Выполнение скрипта прервано!")
             script.exit()
 
         # Приступаем к проверке арматуры проекта
@@ -1040,6 +1041,7 @@ class CreateQualityTableCommand(ICommand):
             output.print_table(table_data=check,
                                title="Показатели качества",
                                columns=["Категории", "Тип ошибки", "Название параметра", "Id"])
+            print("Выполнение скрипта прервано!")
             script.exit()
 
         # Выполняем фильтрацию элементов арматуры по пользовательским исключениям
@@ -1055,6 +1057,7 @@ class CreateQualityTableCommand(ICommand):
             output.print_table(table_data=check,
                                title="Показатели качества",
                                columns=["Категории", "Тип ошибки", "Название параметра", "Id"])
+            print("Выполнение скрипта прервано!")
             script.exit()
 
         # Фильтруем родительские семейства арматуры
@@ -1072,6 +1075,7 @@ class CreateQualityTableCommand(ICommand):
             output.print_table(table_data=check,
                                title="Показатели качества",
                                columns=["Категории", "Тип ошибки", "Название параметра", "Id"])
+            print("Выполнение скрипта прервано!")
             script.exit()
 
         check = self.__view_model.revit_repository.check_rebar_parameters_values(rebar)
@@ -1080,6 +1084,7 @@ class CreateQualityTableCommand(ICommand):
             output.print_table(table_data=check,
                                title="Показатели качества",
                                columns=["Категории", "Тип ошибки", "Название параметра", "Id"])
+            print("Выполнение скрипта прервано!")
             script.exit()
 
         selected_table_type = self.__view_model.selected_table_type
@@ -1380,6 +1385,7 @@ def script_execute(plugin_logger):
         output.print_table(table_data=check,
                            title="Показатели качества",
                            columns=["Категории", "Тип ошибки", "Название параметра", "Id"])
+        print("Выполнение скрипта прервано!")
         script.exit()
 
     revit_repository.filter_concrete_by_main_exceptions()

--- a/КР.tab/Документация.panel/Спецификации.pulldown/Таблицы УПК.pushbutton/script.py
+++ b/КР.tab/Документация.panel/Спецификации.pulldown/Таблицы УПК.pushbutton/script.py
@@ -813,6 +813,10 @@ class Construction:
             element_type = doc.GetElement(element.GetTypeId())
             if element_type.IsExistsParam(CONCRETE_MARK):
                 value = element_type.GetParam(CONCRETE_MARK).AsValueString()
+                if value is None:
+                    print("В элементе с ID \"{}\" не заполнен параметр \"{}\"!".format(element.Id, CONCRETE_MARK))
+                    print("Выполнение скрипта прервано!")
+                    script.exit()
                 concrete_class = "В" + value
                 concrete_classes.add(concrete_class)
         self.__quality_indexes["Класс бетона"] = ", ".join(concrete_classes)


### PR DESCRIPTION
1. После вывода таблицы с ошибками в отчете добавлена запись с целью повышения стабильности вывода отчета (есть проблема, что окно вывода pyRevit подвисает и не печатает таблицу с ошибками, в итоге получается, что показывается пустое окно);
2. Добавлена проверка на null значения параметра "обр_ФОП_Марка бетона B" с остановкой работы скрипта и выводом отчета
3. Добавлена категория проверок на наличие в параметре "обр_ФОП_Форма номер" у арматуры значений < 1000 